### PR TITLE
Fix the correct pdf link for the lam's paper

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -15,7 +15,7 @@
   year={2025},
   selected={true},
   bibtex_show={true},
-  pdf={https://dl.acm.org/doi/10.1145/3729376/}
+  pdf={https://dl.acm.org/doi/10.1145/3729376}
 }
 
 @inproceedings{wuzhuo2025,


### PR DESCRIPTION
The original link has an extra slash at the end, resulting in a 404 error when accessing the PDF.